### PR TITLE
Fix for __str__ on Teradata types causing exception

### DIFF
--- a/sqlalchemy_teradata/types.py
+++ b/sqlalchemy_teradata/types.py
@@ -12,7 +12,23 @@ import datetime
 import teradata.datatypes as td_dtypes
 
 
-class BYTEINT(sqltypes.Integer):
+class _TDType:
+
+    """ Teradata Data Type
+
+    Identifies a Teradata data type. Currently used to override __str__
+    behavior such that the type will get printed without being compiled by the
+    GenericTypeCompiler (which would otherwise result in an exception).
+    """
+
+    def _parse_name(self, name):
+        return name.replace('_', ' ')
+
+    def __str__(self):
+        return self._parse_name(self.__class__.__name__)
+
+
+class BYTEINT(_TDType, sqltypes.Integer):
 
     """ Teradata BYTEINT type
 
@@ -28,7 +44,7 @@ class BYTEINT(sqltypes.Integer):
         super(BYTEINT, self).__init__(**kwargs)
 
 
-class BYTE(sqltypes.BINARY):
+class BYTE(_TDType, sqltypes.BINARY):
 
     """ Teradata BYTE type
 
@@ -50,7 +66,7 @@ class BYTE(sqltypes.BINARY):
         super(BYTE, self).__init__(length=length, **kwargs)
 
 
-class VARBYTE(sqltypes.VARBINARY):
+class VARBYTE(_TDType, sqltypes.VARBINARY):
 
     """ Teradata VARBYTE type
 
@@ -72,7 +88,7 @@ class VARBYTE(sqltypes.VARBINARY):
         super(VARBYTE, self).__init__(length=length, **kwargs)
 
 
-class BLOB(sqltypes.LargeBinary):
+class BLOB(_TDType, sqltypes.LargeBinary):
 
     """ Teradata BLOB type
 
@@ -111,7 +127,7 @@ class BLOB(sqltypes.LargeBinary):
         self.multiplier = multiplier
 
 
-class NUMBER(sqltypes.NUMERIC):
+class NUMBER(_TDType, sqltypes.NUMERIC):
 
     """ Teradata NUMBER type
 
@@ -140,7 +156,7 @@ class NUMBER(sqltypes.NUMERIC):
         super(NUMBER, self).__init__(precision=precision, scale=scale, **kwargs)
 
 
-class TIME(sqltypes.TIME):
+class TIME(_TDType, sqltypes.TIME):
 
     """ Teradata TIME type
 
@@ -164,7 +180,7 @@ class TIME(sqltypes.TIME):
         self.precision = precision
 
 
-class TIMESTAMP(sqltypes.TIMESTAMP):
+class TIMESTAMP(_TDType, sqltypes.TIMESTAMP):
 
     """ Teradata TIMESTAMP type
 
@@ -187,7 +203,7 @@ class TIMESTAMP(sqltypes.TIMESTAMP):
         self.precision = precision
 
 
-class _TDInterval(types.UserDefinedType):
+class _TDInterval(_TDType, types.UserDefinedType):
 
     """ Base class for the Teradata INTERVAL sqltypes """
 
@@ -626,7 +642,7 @@ class INTERVAL_SECOND(_TDInterval):
         return process
 
 
-class _TDPeriod(types.UserDefinedType):
+class _TDPeriod(_TDType, types.UserDefinedType):
 
     """ Base class for the Teradata Period sqltypes """
 
@@ -723,7 +739,7 @@ class PERIOD_TIMESTAMP(_TDPeriod):
         self.timezone       = timezone
 
 
-class CHAR(sqltypes.CHAR):
+class CHAR(_TDType, sqltypes.CHAR):
 
     """ Teradata CHAR type
 
@@ -756,7 +772,7 @@ class CHAR(sqltypes.CHAR):
         self.charset = charset
 
 
-class VARCHAR(sqltypes.String):
+class VARCHAR(_TDType, sqltypes.String):
 
     """ Teradata VARCHAR type
 
@@ -783,7 +799,7 @@ class VARCHAR(sqltypes.String):
         self.charset = charset
 
 
-class CLOB(sqltypes.CLOB):
+class CLOB(_TDType, sqltypes.CLOB):
 
     """ Teradata CLOB type
 

--- a/test/unit/test_types.py
+++ b/test/unit/test_types.py
@@ -179,6 +179,9 @@ class TestCompileTDTypes(fixtures.TestBase):
         assert(self._compile(INTERVAL_MINUTE())           == 'INTERVAL MINUTE')
         assert(self._compile(INTERVAL_MINUTE_TO_SECOND()) == 'INTERVAL MINUTE TO SECOND')
         assert(self._compile(INTERVAL_SECOND())           == 'INTERVAL SECOND')
+        assert(self._compile(PERIOD_DATE())               == 'PERIOD(DATE)')
+        assert(self._compile(PERIOD_TIME())               == 'PERIOD(TIME)')
+        assert(self._compile(PERIOD_TIMESTAMP())          == 'PERIOD(TIMESTAMP)')
 
     def test_compile_character(self):
         """
@@ -260,3 +263,38 @@ class TestCompileTDTypes(fixtures.TestBase):
 
                 assert(self._compile(INTERVAL_SECOND(prec, fsec)) ==
                     'INTERVAL SECOND({}, {})'.format(prec, fsec))
+
+class TestStrTDTypes(fixtures.TestBase):
+
+    def test_str_default(self):
+        """
+        Test printing out (calling str) on each of the data types implemented
+        in types.py.
+        """
+
+        assert(str(TIME())                      == 'TIME')
+        assert(str(TIMESTAMP())                 == 'TIMESTAMP')
+        assert(str(CHAR())                      == 'CHAR')
+        assert(str(VARCHAR())                   == 'VARCHAR')
+        assert(str(CLOB())                      == 'CLOB')
+        assert(str(NUMBER())                    == 'NUMBER')
+        assert(str(BYTEINT())                   == 'BYTEINT')
+        assert(str(BYTE())                      == 'BYTE')
+        assert(str(VARBYTE())                   == 'VARBYTE')
+        assert(str(BLOB())                      == 'BLOB')
+        assert(str(INTERVAL_YEAR())             == 'INTERVAL YEAR')
+        assert(str(INTERVAL_YEAR_TO_MONTH())    == 'INTERVAL YEAR TO MONTH')
+        assert(str(INTERVAL_MONTH())            == 'INTERVAL MONTH')
+        assert(str(INTERVAL_DAY())              == 'INTERVAL DAY')
+        assert(str(INTERVAL_DAY_TO_HOUR())      == 'INTERVAL DAY TO HOUR')
+        assert(str(INTERVAL_DAY_TO_MINUTE())    == 'INTERVAL DAY TO MINUTE')
+        assert(str(INTERVAL_DAY_TO_SECOND())    == 'INTERVAL DAY TO SECOND')
+        assert(str(INTERVAL_HOUR())             == 'INTERVAL HOUR')
+        assert(str(INTERVAL_HOUR_TO_MINUTE())   == 'INTERVAL HOUR TO MINUTE')
+        assert(str(INTERVAL_HOUR_TO_SECOND())   == 'INTERVAL HOUR TO SECOND')
+        assert(str(INTERVAL_MINUTE())           == 'INTERVAL MINUTE')
+        assert(str(INTERVAL_MINUTE_TO_SECOND()) == 'INTERVAL MINUTE TO SECOND')
+        assert(str(INTERVAL_SECOND())           == 'INTERVAL SECOND')
+        assert(str(PERIOD_DATE())               == 'PERIOD DATE')
+        assert(str(PERIOD_TIME())               == 'PERIOD TIME')
+        assert(str(PERIOD_TIMESTAMP())          == 'PERIOD TIMESTAMP')


### PR DESCRIPTION
## High level description of this Pull-request
Dialect-specific types' str() method currently does not work correctly. This is because for external dialects, when str() is called on a type, the default GenericTypeCompiler is tasked with compiling the type. This is problematic because only the dialect-specific `TeradataTypeCompiler` will know how to render Teradata types. This PR provides a very basic workaround by implementing a base class `_TDType` that overrides `__str__` to effectively just print out the class name. Note that this is a departure from the standard types implemented by SQLAlchemy in that they expect `__str__` to give the compiled textual SQL (equivalent to calling `type_.compile(dialect=TeradataDialect)`), while ours will only print out the type (name). We may be able to improve upon this in the future, but for now this patch should be sufficient to allow users to more easily print out Teradata types.

## Related Issues
- #53 

## Reviewers
- @sandan 

# CHECKLIST:
Make sure all items are marked when you submit the pull-request.

- [x] Relevant documentation for functions, tests, classes, the wiki, etc. have been made
- [x] Necessary unit tests in tests/ pass with no errors
- [x] Necessary integration tests in tests/ pass with no errors
- [ ] Update the CHANGELOG.md with a summary of your changes if requested
