### PR TITLE
Compile binary operator refactor

### DIFF
--- a/sqlalchemy_teradata/compiler.py
+++ b/sqlalchemy_teradata/compiler.py
@@ -38,23 +38,13 @@ class TeradataCompiler(compiler.SQLCompiler):
 
         return pre
 
-    def visit_binary(self, binary, override_operator=None,
-                     eager_grouping=False, **kw):
-        """
-        Handles the overriding of binary operators. Any custom binary operator
-        definition should be placed in the custom_ops dict.
-        """
-        custom_ops = {
-            operators.ne:  '<>',
-            operators.mod: 'MOD'
-        }
+    def visit_mod_binary(self, binary, operator, **kw):
+        return self.process(binary.left, **kw) + " MOD " + \
+            self.process(binary.right, **kw)
 
-        if binary.operator in custom_ops:
-            binary.operator = operators.custom_op(
-                opstring=custom_ops[binary.operator])
-
-        return compiler.SQLCompiler.visit_binary(
-            self, binary, override_operator, eager_grouping, **kw)
+    def visit_ne_binary(self, binary, operator, **kw):
+        return self.process(binary.left, **kw) + " <> " + \
+            self.process(binary.right, **kw)
 
     def limit_clause(self, select, **kwargs):
         """Limit after SELECT is implemented in get_select_precolumns"""


### PR DESCRIPTION
## High level description of this Pull-request
The dialect is currently handling the compilation of non-generic binary operators by overriding `visit_binary()` in compiler.py. In fact, this is not necessary as the compilation (visit) method of each binary operator can actually individually be implemented in the `TeradataCompiler`. This PR amends the previous implementation into this more standard design.

## Related Issues
NA

## Reviewers
- @sandan 

# CHECKLIST:
Make sure all items are marked when you submit the pull-request.

- [x] Relevant documentation for functions, tests, classes, the wiki, etc. have been made
- [x] Necessary unit tests in tests/ pass with no errors
- [x] Necessary integration tests in tests/ pass with no errors
- [ ] Update the CHANGELOG.md with a summary of your changes if requested
