### PR TITLE
Make username and password optional in create_engine

### DIFF
--- a/sqlalchemy_teradata/dialect.py
+++ b/sqlalchemy_teradata/dialect.py
@@ -90,7 +90,7 @@ class TeradataDialect(default.DefaultDialect):
     def create_connect_args(self, url):
       if url is not None:
         params = super(TeradataDialect, self).create_connect_args(url)[1]
-        cargs = ("Teradata", params['host'], params['username'], params['password'])
+        cargs = ("Teradata", params['host'], params.get('username', ''), params.get('password', ''))
         cparams = {p:params[p] for p in params if p not in\
                                 ['host', 'username', 'password']}
         return (cargs, cparams)


### PR DESCRIPTION
Make username and password optional in create_engine in case the user wants to do something like:

from sqlalchemy import create_engine
engine = create_engine('teradata://host/?trusted_connection=yes')

This is useful if Teradata is set to use integrated security.
At the moment the above example would generate a KeyError in Python.

## High level description of this Pull-request
Include motivations, reasons, and background to add context to your contribution.
Include a description of changes associated with your commit(s)

## Related Issues
- List all related issues or NA

## Reviewers
- Use @Mentions to specify the reviewers for your PR.

# CHECKLIST:
Make sure all items are marked when you submit the pull-request.

- [ ] Relevant documentation for functions, tests, classes, the wiki, etc. have been made
- [ ] Necessary unit tests in tests/ pass with no errors
- [ ] Necessary integration tests in tests/ pass with no errors
- [ ] Update the CHANGELOG.md with a summary of your changes if requested
